### PR TITLE
Load Bazel rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,7 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
+load("@bazel_tools//tools/build_defs/repo:maven_rules.bzl", "maven_jar")
 
 maven_jar(
     name = "junit4",


### PR DESCRIPTION
Fix the following error:

```
$ bazel run //java/gulava:Demo
Starting local Bazel server and connecting to it...
ERROR: /Users/jing/code/github/gulava/WORKSPACE:21:1: name 'maven_jar' is not defined
ERROR: error loading package '': Encountered error while reading extension file 'tools/build_defs/repo/http.bzl': no such package '@bazel_tools//tools/build_defs/repo': error loading package 'external': Could not load //external package
INFO: Elapsed time: 2.826s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
FAILED: Build did NOT complete successfully (0 packages loaded)
```
I am using Bazel 3.7.0 on macOS.

